### PR TITLE
Fix templating of disabled peers

### DIFF
--- a/templates/peers.conf.erb
+++ b/templates/peers.conf.erb
@@ -18,7 +18,7 @@ protocol bgp <%= session_name(session) %> from <%= session_template_name(session
   password "<%= session.md5 %>";
   <%- end -%>
   <%- if session.disabled -%>
-  disabled "{{ session.disabled }}";
+  disabled yes;
   <%- end -%>
   <%- if session.route_reflector -%>
   rr client;


### PR DESCRIPTION
This was a vestige of an old jinja2 template that I must have forgotten to update when I ported this all over to Ruby.