### PR TITLE
Make sure that originated routes are in RIB

### DIFF
--- a/out/router.fqdn.example/static.conf
+++ b/out/router.fqdn.example/static.conf
@@ -1,11 +1,15 @@
 protocol static {
   ipv4;
 
+  # Originated routes
+  route 198.51.100.0/24 unreachable;
 }
 
 protocol static {
   ipv6;
 
+  # Originated routes
+  route 2001:db8::/32 unreachable;
 }
 
 # vim: set ft=bird nofoldenable:

--- a/templates/static.conf.erb
+++ b/templates/static.conf.erb
@@ -1,16 +1,33 @@
 protocol static {
   ipv4;
 
-<%- Array(config&.static_routes&.v4).each do |route| -%>
+<%- if config&.originations&.v4 -%>
+  # Originated routes
+  <%- Array(config&.originations&.v4).each do |route| -%>
+  route <%= route %> unreachable;
+  <%- end -%>
+<%- end -%>
+<%- if config&.static_routes&.v4 -%>
+  # Static routes
+  <%- Array(config&.static_routes&.v4).each do |route| -%>
   route <%= route %>;
+  <%- end -%>
 <%- end -%>
 }
 
 protocol static {
   ipv6;
 
-<%- Array(config&.static_routes&.v6).each do |route| -%>
+<%- if config&.originations&.v6 -%>
+  # Originated routes
+  <%- Array(config&.originations&.v6).each do |route| -%>
+  route <%= route %> unreachable;
+  <%- end -%>
+<%- end -%>
+<%- if config&.static_routes&.v6 -%>
+  <%- Array(config&.static_routes&.v6).each do |route| -%>
   route <%= route %>;
+  <%- end -%>
 <%- end -%>
 }
 


### PR DESCRIPTION
Earlier today I attempted to drain a router that was the last in our network architecture to not yet be on this configuration (it was using an old jinja2 template). In the old configuration, I had explicitly set static unreachable routes in BIRD for originated prefixes, and forgot to port those over to this new configuration.

When the router with the old configuration's iBGP session was drained, the origination of our prefixes stopped causing an outage of all Neptune Networks prefixes.

This pull request fixes the bug by adding a static [unreachable] route for any prefixes that are originated.