### PR TITLE
Allow absent v4/v6 originations in config

### DIFF
--- a/templates/bird.conf.erb
+++ b/templates/bird.conf.erb
@@ -4,22 +4,30 @@ define OUR_AS = <%= config.asn %>;
 define REGION_ID = <%= config.region_id %>;
 define SITE_ID = <%= config.site_id %>;
 
+<%- if config.originations.v4 -%>
 define ORIGINATED_PREFIXES_4 = [
   <%= config.originations.v4.join(",\n  ") %>
 ];
 
+<%- end -%>
+<%- if config.originations.v6 -%>
 define ORIGINATED_PREFIXES_6 = [
   <%= config.originations.v6.join(",\n  ") %>
 ];
 
+<%- end -%>
+<%- if config.originations.v4 -%>
 define OUR_INTERNAL_PREFIXES_4 = [
   <%= config.originations.v4.map { |p| "#{p}+" }.join(",\n  ") %>
 ];
 
+<%- end -%>
+<%- if config.originations.v6 -%>
 define OUR_INTERNAL_PREFIXES_6 = [
   <%= config.originations.v6.map { |p| "#{p}+" }.join(",\n  ") %>
 ];
 
+<%- end -%>
 <%- if config.blacklist.v4 -%>
 define GLOBAL_BLACKLIST_4 = [
   <%= config.blacklist.v4.join(",\n  ") %>


### PR DESCRIPTION
This pull request updates the main `bird.conf` template to support configurations that don't have a `v4` or `v6` `origination` defined.

Previous to this pull request, the main render method would fail when trying to join together nonexistent prefixes to be originated. Now we have a simple check to see if they exist before inserting them into the bird template.

##

Resolves https://github.com/neptune-networks/peering/issues/5