### PR TITLE
Fix bug where allowed_prefixes defaulted open

### DIFF
--- a/config/router.fqdn.example.yml
+++ b/config/router.fqdn.example.yml
@@ -191,6 +191,11 @@ bgp:
         remote:
           v4: '203.0.113.220'
           v6: 'fd00:504:36:0:3:2:0'
+        allowed_prefixes:
+          v4:
+            - '192.0.2.0/24'
+          v6:
+            - '2001:db8::/32'
 
   peers:
     defaults:

--- a/out/router.fqdn.example/peers.conf
+++ b/out/router.fqdn.example/peers.conf
@@ -93,6 +93,9 @@ define AS_SET_FOR_65551_4 = [
     216.190.188.0/22
 ];
 
+define PREFIX_WHITELIST_FOR_65551_4 = [
+    192.0.2.0/24
+];
 
 protocol bgp CUSTOMER_AS65551_v4 from customer4 {
   description "ACME Inc.";
@@ -104,6 +107,9 @@ protocol bgp CUSTOMER_AS65551_v4 from customer4 {
     import filter {
       if !(net ~ AS_SET_FOR_65551_4) then
         reject "prefix is not in IRR AS SET AS-NEPTUNE-NETWORKS - REJECTING ", net;
+
+      if !(net ~ PREFIX_WHITELIST_FOR_65551_4) then
+        reject "prefix is not in prefix whitelist - REJECTING ", net;
 
       customer_import();
     };
@@ -180,6 +186,9 @@ define AS_SET_FOR_65551_6 = [
     2a0f:9400:735f::/48
 ];
 
+define PREFIX_WHITELIST_FOR_65551_6 = [
+    2001:db8::/32
+];
 
 protocol bgp CUSTOMER_AS65551_v6 from customer6 {
   description "ACME Inc.";
@@ -191,6 +200,9 @@ protocol bgp CUSTOMER_AS65551_v6 from customer6 {
     import filter {
       if !(net ~ AS_SET_FOR_65551_6) then
         reject "prefix is not in IRR AS SET AS-NEPTUNE-NETWORKS - REJECTING ", net;
+
+      if !(net ~ PREFIX_WHITELIST_FOR_65551_6) then
+        reject "prefix is not in prefix whitelist - REJECTING ", net;
 
       customer_import();
     };

--- a/templates/partials/filters/_customer.conf.erb
+++ b/templates/partials/filters/_customer.conf.erb
@@ -7,12 +7,12 @@
         reject "prefix is not in IRR AS SET <%= session.irr %> - REJECTING ", net;
 
       <%- end -%>
-      <%- if session.allowed_prefixes&.public_send(session.protocol) -%>
+      <%- if session.allowed_prefixes&.public_send(session.protocol)&.any? -%>
       if !(net ~ PREFIX_WHITELIST_FOR_<%= session.asn %>_<%= session.protocol_number %>) then
         reject "prefix is not in prefix whitelist - REJECTING ", net;
 
-      <%- end -%>
       customer_import();
+      <%- end -%>
     <%- else -%>
       reject;
     <%- end -%>


### PR DESCRIPTION
This pull request resolves a problem where the absence of `allowed_prefixes` would still allow announcements to be imported. 

This may be controversial for other users who don't have whitelists defined for every customer announcement, but it is an important change for Neptune Networks. If anyone has feedback on this and would like an alternative, I would be open to exploring other options.