### PR TITLE
Reject imported routes without IRR/allowed prefixes

### DIFF
--- a/templates/partials/filters/_customer.conf.erb
+++ b/templates/partials/filters/_customer.conf.erb
@@ -18,6 +18,11 @@
     <%- end -%>
     };
 
+  <%- else -%>
+    import filter {
+      reject;
+    }
+
   <%- end -%>
     export filter {
       <%- if session.communities&.export -%>


### PR DESCRIPTION
This pull request updates the customer template to reject any imported prefixes if the BGP configuration doesn't have any allowed prefixes or an IRR record. Without it, the `customer4` template would fall back to the `default_import()` function which would import the routes:

https://github.com/neptune-networks/peering/blob/5a05685eb211e443d261bc35180ef4c5a6e4069e/templates/bird.conf.erb#L429